### PR TITLE
Update mongodbhandler.py

### DIFF
--- a/jsonklog/handlers/mongodbhandler.py
+++ b/jsonklog/handlers/mongodbhandler.py
@@ -28,7 +28,7 @@ class MongoDBHandler(RequireJSONFormatter):
                  collection="logs"):
 
         logging.Handler.__init__(self)
-        self.connection = pymongo.Connection(host, port)
+        self.connection = pymongo.MongoClient(host, port)
         self.db = self.connection[db]
         self.collection = self.db[collection]
 


### PR DESCRIPTION
latest pymongo library doesn't have the attribute 'Connection'.
Changed it to MongoClient.
